### PR TITLE
Fix module "redis.connection" does not define a "HiredisParser" attribute/class

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -163,7 +163,7 @@ chown -R $app: "$final_path"
 	sudo --user=$app $final_path/venv/bin/pip install --force-reinstall --no-binary :all: cffi
 	# Still needed with latest version of weblate?
 	sudo --user=$app BORG_OPENSSL_PREFIX=/usr/lib/x86_64-linux-gnu/ $final_path/venv/bin/pip install Weblate=="$(ynh_app_upstream_version)"
-	sudo --user=$app $final_path/venv/bin/pip install psycopg2-binary ruamel.yaml aeidon phply
+	sudo --user=$app $final_path/venv/bin/pip install psycopg2-binary ruamel.yaml aeidon phply redis[hiredis]
 	#pip install pytz python-bidi PyYaML Babel pyuca pylibravatar py3dns psycopg2-binary phply django-redis hiredis aeidon ruamel.yaml
 	# specific to YunoHost package:
 	sudo --user=$app $final_path/venv/bin/pip install django_sendmail_backend

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -197,7 +197,7 @@ upgrade() {
 		sudo --user=$app $final_path/venv/bin/pip install --force-reinstall --no-binary :all: cffi
 		# Still needed with latest version of weblate?
 		sudo --user=$app $final_path/venv/bin/pip install --upgrade Weblate=="$new_version"
-		sudo --user=$app $final_path/venv/bin/pip install psycopg2-binary ruamel.yaml aeidon phply
+		sudo --user=$app $final_path/venv/bin/pip install --upgrade psycopg2-binary ruamel.yaml aeidon phply redis[hiredis]
 		#pip install pytz python-bidi PyYaML Babel pyuca pylibravatar py3dns psycopg2-binary phply django-redis hiredis aeidon ruamel.yaml
 		# specific to YunoHost package:
 		sudo --user=$app $final_path/venv/bin/pip install django_sendmail_backend


### PR DESCRIPTION
cf. latest automated jobs failing and https://github.com/jazzband/django-redis/issues/676

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
